### PR TITLE
Centered BusySpinner translation with proper X/Y offsets

### DIFF
--- a/extensions/SGDEX/Views/OtherNodes/Views/LoadingFacade/LoadingFacade.brs
+++ b/extensions/SGDEX/Views/OtherNodes/Views/LoadingFacade/LoadingFacade.brs
@@ -6,7 +6,7 @@ sub Init()
 
     busySpinner = m.top.CreateChild("BusySpinner")
     busySpinner.poster.uri = "pkg:/components/SGDEX/Images/loader.png"
-    busySpinner.translation = [587, 308]
+    busySpinner.translation = [565, 285]
 
     m.top.busySpinner = busySpinner
 end sub


### PR DESCRIPTION
Centered BusySpinner translation with proper X/Y offsets according to
1280x720 resolution (HD) and 150x150 logo (Images/loader.png)

[(1280/2 - 150/2), (720/2 - 150/2)]

This resolves the center position of the BusySpinner under these known cases:
- updating handlerConfigRAF field of MediaView (using SGDEX RAFHandler with MediaView)