### PR TITLE
swap out bookmark updating for playStart updating

### DIFF
--- a/extensions/SGDEX/Views/OtherNodes/ItemComponents/StandardGridItemComponent/StandardGridItemComponent.brs
+++ b/extensions/SGDEX/Views/OtherNodes/ItemComponents/StandardGridItemComponent/StandardGridItemComponent.brs
@@ -18,7 +18,7 @@ sub onContentSet()
         ' contentSetLine is field to check if text is set to label
         setLabelDataOrHide(m.line1, content.shortDescriptionLine1)
         setLabelDataOrHide(m.line2, content.shortDescriptionLine2)
-        setDurationBarData(content.length, content.bookmarkposition, content.hideItemDurationBar <> true)
+        setDurationBarData(content.length, content.playStart, content.hideItemDurationBar <> true)
         updateLabelsLayout()
     end if
 end sub
@@ -103,10 +103,10 @@ sub setLabelDataOrHide(label as Object, text as String)
     end if
 end sub
 
-sub setDurationBarData(length as Integer,BookmarkPosition as Integer, showDurationBar as Boolean)
-    if showDurationBar and length > 0 and BookmarkPosition > 0 and bookmarkPosition < length
+sub setDurationBarData(length as Integer, playStart as Integer, showDurationBar as Boolean)
+    if showDurationBar and length > 0 and playStart > 0 and playStart < length
         m.durationBar.length            = length
-        m.durationBar.BookmarkPosition  = BookmarkPosition
+        m.durationBar.playStart  = playStart
         m.durationBar.visible           = true
         m.durationBar.scale             = [1,1]
     else

--- a/extensions/SGDEX/Views/OtherNodes/Views/DurationBar/DurationBar.brs
+++ b/extensions/SGDEX/Views/OtherNodes/Views/DurationBar/DurationBar.brs
@@ -28,9 +28,9 @@ Sub OnBackgroundColorChanged()
 end Sub
 
 'update progress on duration bar
-Sub UpdateBookmark()
-    if m.top.length > 0 AND m.top.length > m.top.BookmarkPosition
-        progress = Int(m.top.BookmarkPosition / m.top.length * 100)
+Sub UpdatePlayStart()
+    if m.top.length > 0 AND m.top.length > m.top.playStart
+        progress = Int(m.top.playStart / m.top.length * 100)
         if progress > 100
             progress = 100
         else if progress < 0

--- a/extensions/SGDEX/Views/OtherNodes/Views/DurationBar/DurationBar.xml
+++ b/extensions/SGDEX/Views/OtherNodes/Views/DurationBar/DurationBar.xml
@@ -13,9 +13,9 @@
         <!-- preffered color of progress on duration bar -->
         <field id="progressColor" type="color" alias="progress.color" />
         <!-- current playback position -->
-        <field id="length" type="int" onChange="UpdateBookmark" />
+        <field id="length" type="int" onChange="UpdatePlayStart" />
         <!-- stored bookmark playback position -->
-        <field id="bookmarkPosition" type="int" onChange="UpdateBookmark" />     
+        <field id="playStart" type="int" onChange="UpdatePlayStart" />     
     </interface> 
 
     <script type="text/brightscript" uri= "DurationBar.brs" />


### PR DESCRIPTION
V8 roku depricates the content-meta tags for BookmarkPosition. Updates the DurationBar and StandardGridItemComponent to properly update the playStart field instead of BookmarkPosition.

https://developer.roku.com/docs/developer-program/getting-started/architecture/content-metadata.md